### PR TITLE
Removed ##.gb_g.gb_rc.gb_sc

### DIFF
--- a/fanboy-cookiemonster.txt
+++ b/fanboy-cookiemonster.txt
@@ -6508,7 +6508,6 @@ _site_cookie_
 ##.gaicoMessage
 ##.gb-cookie-consent
 ##.gb-gnb__notice-bar
-##.gb_g.gb_rc.gb_sc
 ##.gdl-cookie-dialog
 ##.gdpr-privacy-banner
 ##.general-cookie-notification


### PR DESCRIPTION
With the new google news design, this was causing the navigation menu to be blocked.