### PR TITLE
A: github.com to third-party favicon.ico whitelist

### DIFF
--- a/enhancedstats-addon.txt
+++ b/enhancedstats-addon.txt
@@ -366,7 +366,7 @@ _wtBase.js
 _wtbaseV2.
 _wtInit.js
 ! popads tracking
-/favicon.ico$image,third-party,domain=~stackexchange.com|~stackoverflow.com|~askubuntu.com|~reddit.com|~4chan.org|~twitter.com|~live.com|~espn.com
+/favicon.ico$image,third-party,domain=~stackexchange.com|~stackoverflow.com|~askubuntu.com|~github.com|~reddit.com|~4chan.org|~twitter.com|~live.com|~espn.com
 ! push notifications test filter
 ##.open.pushModal
 !


### PR DESCRIPTION
GitHub moves the favicon to https://github.githubassets.com/favicon.ico