### PR TITLE
Add ebay.com.au to third-party favicon.ico whitelist

### DIFF
--- a/enhancedstats-addon.txt
+++ b/enhancedstats-addon.txt
@@ -366,7 +366,7 @@ _wtBase.js
 _wtbaseV2.
 _wtInit.js
 ! popads tracking
-/favicon.ico$image,third-party,domain=~github.com|~stackexchange.com|~stackoverflow.com|~askubuntu.com|~reddit.com|~4chan.org|~twitter.com|~live.com|~espn.com
+/favicon.ico$image,third-party,domain=~github.com|~stackexchange.com|~stackoverflow.com|~askubuntu.com|~reddit.com|~4chan.org|~twitter.com|~live.com|~espn.com|~ebay.com.au
 ! push notifications test filter
 ##.open.pushModal
 !


### PR DESCRIPTION
https://www.ebay.com.au homepage is loading it's favicon from https://pages.ebay.com/favicon.ico

Everywhere else on the website they are loading the normal https://www.ebay.com.au/favicon.ico

