### PR TITLE
Added wayfair.com to Admiral script regex exceptions list

### DIFF
--- a/enhancedstats-addon.txt
+++ b/enhancedstats-addon.txt
@@ -1345,7 +1345,7 @@ gosugamers.net###footerWrapper
 ! symbolab.com
 symbolab.com##.tooltipster-show
 ! Admiral
-/\.com/.*[a-f0-9]{110}/$script,image,third-party,domain=~parship.com|~feedbin.com|~aliexpress.com|~alipay.com|~bilibili.com|~namu.wiki|~fastmail.com
+/\.com/.*[a-f0-9]{110}/$script,image,third-party,domain=~parship.com|~feedbin.com|~aliexpress.com|~alipay.com|~bilibili.com|~namu.wiki|~fastmail.com|~wayfair.com
 ! /\.com\/.*[0-9]{6,9}\/\?/$popup
 @@||githubusercontent.com^$image
 @@||vmp.boldchat.com/aid/$script


### PR DESCRIPTION
Wayfair loads all of its page action handling javascript (from its CDN domain, wfcdn.com) using filenames that match this regex. Blocking these scripts breaks most user actions on the site's product pages (dropdown menus, expandable sections, etc).

These scripts are needed purely for page action handling reasons -- Wayfair does not intentionally track or try to circumvent adblock usage (either with Admiral or any other service), and the site doesn't even run any external-facing ads.

Note that this regex filter already has several exception domains, including popular sites such as aliexpress.com and fastmail.com

Example of one of the scripts in question:
![Screen Shot 2019-03-31 at 5 41 46 PM](https://user-images.githubusercontent.com/14853420/55295544-4a8a5100-53dc-11e9-9565-2a1d03a26d11.png)
