### PR TITLE
Add jit.si to third-party favicon whitelist

### DIFF
--- a/enhancedstats-addon.txt
+++ b/enhancedstats-addon.txt
@@ -511,7 +511,7 @@ wccftech.com#$#abort-current-inline-script window.NewzmateConfig
 ! https://middycdn-a.akamaihd.net/bootstrap/bootstrap.js (From tennis365.com)
 ||akamaihd.net/bootstrap/bootstrap.js
 ! favicon tracking
-/favicon.ico$image,third-party,domain=~streameast.live|~apple.com|~douban.com|~bahn.de|~winfuture.de|~bt.com|~ebay.com.au|~ebay.com|~ebay.co.uk|~go.com|~github.com|~microsoft.com|~stackexchange.com|~stackoverflow.com|~askubuntu.com|~reddit.com|~4chan.org|~twitter.com|~live.com|~espn.com|~yahoo.com
+/favicon.ico$image,third-party,domain=~streameast.live|~apple.com|~douban.com|~bahn.de|~winfuture.de|~bt.com|~ebay.com.au|~ebay.com|~ebay.co.uk|~go.com|~github.com|~microsoft.com|~stackexchange.com|~stackoverflow.com|~askubuntu.com|~reddit.com|~4chan.org|~twitter.com|~live.com|~espn.com|~yahoo.com|~jit.si
 ! push notifications test filter
 ##.open.pushModal
 !


### PR DESCRIPTION
'meet.jit.si' loads it from 'https://web-cdn.jitsi.net/meetjitsi_4860.1487/images/favicon.ico?v=1'