### PR TITLE
Add more Stack Exchange sites to favicon exception

### DIFF
--- a/enhancedstats-addon.txt
+++ b/enhancedstats-addon.txt
@@ -433,7 +433,7 @@ wccftech.com##+js(acis, window.NewzmateConfig)
 ! https://middycdn-a.akamaihd.net/bootstrap/bootstrap.js (From tennis365.com)
 ||akamaihd.net/bootstrap/bootstrap.js
 ! favicon tracking
-/favicon.ico$image,third-party,domain=~streameast.live|~apple.com|~douban.com|~bahn.de|~winfuture.de|~bt.com|~ebay.com.au|~ebay.com|~ebay.co.uk|~go.com|~github.com|~microsoft.com|~stackexchange.com|~stackoverflow.com|~askubuntu.com|~reddit.com|~4chan.org|~twitter.com|~live.com|~espn.com|~yahoo.com|~jit.si
+/favicon.ico$image,third-party,domain=~streameast.live|~apple.com|~douban.com|~bahn.de|~winfuture.de|~bt.com|~ebay.com.au|~ebay.com|~ebay.co.uk|~go.com|~github.com|~microsoft.com|~stackexchange.com|~stackoverflow.com|~askubuntu.com|~superuser.com|~serverfault.com|~mathoverflow.com|~stackapps.com|~reddit.com|~4chan.org|~twitter.com|~live.com|~espn.com|~yahoo.com|~jit.si
 ! push notifications test filter
 ##.open.pushModal
 !


### PR DESCRIPTION
Source: https://meta.stackexchange.com/questions/248453/why-do-some-stack-exchange-sites-have-their-own-domain-names

https://seasonedadvice.com/ just redirects so I left it out.