### PR TITLE
Fix issue #1511 and #1515

### DIFF
--- a/enhancedstats-addon.txt
+++ b/enhancedstats-addon.txt
@@ -1618,7 +1618,6 @@ reddit.com##+js(acis, addScript)
 reddit.com##+js(acis, adSlots)
 reddit.com##+js(acis, googletag.pubads)
 reddit.com##+js(acis, window.__adslots)
-reddit.com##._3RPJ8hHnfFohktLZca18J6
 reddit.com##.dfp-ad-container
 reddit.com##.email-collection-banner
 reddit.com##.premium-banner

--- a/enhancedstats-addon.txt
+++ b/enhancedstats-addon.txt
@@ -2016,6 +2016,7 @@ wordsense.eu##[data-ad-client]
 !
 @@||techradar.com^$generichide
 techradar.com##.buttons-social
+techradar.com##.dfp-leaderboard-container
 techradar.com##.inbody__newsletter
 techradar.com##.newsletter-signup
 techradar.com##.socialite-widget


### PR DESCRIPTION
See issue #1515 

<details><summary> Text of the issue </summary> 

### URL address of the web page

`https://www.reddit.com/`

### Category

ads

### Describe the issue

As you can see in the screenshots the rule `##._3RPJ8hHnfFohktLZca18J6` makes also some blocks disappear which should not be blocked. 

**Note** `Fanboy's Enhanced Tracking List` has this rule so please remove this rule. 

uBlock has this rule `.ad-banner:not([style="height: 5px; width: 5px; position: absolute; top: 0;"]):not(.blocker-tester + .ad-banner)` which does the trick: only remove empty spaces but not the other blocks at the right side of the site.

### Screenshot(s)

<details>
<summary>Screenshot 1</summary>

![image](https://user-images.githubusercontent.com/81161435/166661022-d3d0e971-905d-436e-a36e-9fa3a43bde26.png)

</details>

<details>
<summary>Screenshot 2</summary>

![image](https://user-images.githubusercontent.com/81161435/166661101-fac0e356-fa3e-42a4-bf68-c2866211cb24.png)

</details>

<details>
<summary>Screenshot 3</summary>

![image](https://user-images.githubusercontent.com/81161435/166661198-aa7c856d-6c39-464f-aaee-f80b9d0e5324.png)

</details>

### Configuration

<details>

```yaml
uBlock Origin: 1.42.2
Chromium: 101
filterset (summary): 
  network: 69103
  cosmetic: 44860
  scriptlet: 16823
  html: 0
listset (total-discarded, last updated): 
  removed: 
    ublock-badware: null
    ublock-privacy: null
    ublock-abuse: null
    ublock-quick-fixes: null
    urlhaus-1: null
    plowe-0: null
    NLD-0: null
  added: 
    https://fanboy.co.nz/enhancedstats.txt: 2996-10, 1h.21m
    https://raw.githubusercontent.com/JohnyP36/Personal-List/main/Personal%20List%20(uBo).txt: 2069-0, 1h.21m
  default: 
    user-filters: 214-0, never
    ublock-filters: 30946-90, 1h.16m
    ublock-unbreak: 1777-10, 1h.15m
    easylist: 66373-139, 1h.14m
    easyprivacy: 26935-194, 1h.13m
filterset (user): [array of 162 redacted]
trustedset: 
  added: [array of 12 redacted]
  removed: 
    about-scheme
    chrome-extension-scheme
    chrome-scheme
    edge-scheme
    moz-extension-scheme
    opera-scheme
    vivaldi-scheme
    wyciwyg-scheme
switchRuleset: 
  added: [array of 1 redacted]
  removed: 
    no-large-media: behind-the-scene false
hostRuleset: 
  added: [array of 7 redacted]
  removed: 
    behind-the-scene * * noop
    behind-the-scene * image noop
    behind-the-scene * 3p noop
    behind-the-scene * inline-script noop
    behind-the-scene * 1p-script noop
    behind-the-scene * 3p-script noop
    behind-the-scene * 3p-frame noop
urlRuleset: 
  added: [array of 9 redacted]
modifiedUserSettings: 
  advancedUserEnabled: true
  contextMenuEnabled: false
  webrtcIPAddressHidden: true
modifiedHiddenSettings: 
  autoCommentFilterTemplate: -
  cacheStorageAPI: indexedDB
  filterAuthorMode: true
  popupFontSize: 11px
  uiFlavor: classic
  updateAssetBypassBrowserCache: true
supportStats: 
  allReadyAfter: 19417 ms
  maxAssetCacheWait: 1099 ms
popupPanel: 
  blocked: 77
  blockedDetails: 
    reddit.com: 12
    doubleclick.net: 2
    gfycat.com: 1
    google-analytics.com: 1
    google.com: 2
    redditmedia.com: 1
    redditstatic.com: 51
    streamable.com: 1
    youtube.com: 6
```
</details>

</details>

----

See issue #1511 

<details> <summary> Text of the issue </summary>

<!-- 2
Note: If you're a website owner that has been specifically targeted, fix the site before reporting. 
Remove revolving ad servers, popup ads, adblock countering etc. Only then will this request be reviewed. -->

<!-- Any additions, changes or removals is at the Authors discretion. 
You're free to counterargue (to a certain point) if you disagree with the decision. 
To avoid being banned, don't constantly re-open or create new (related) issue reports.
-->

<!-- If you fail to fill in this form, THIS ISSUE REPORT WILL BE CLOSED. -->

<!-- Include the website URL in the Title line of this issue report -->

### List the website(s) you're having issues:

`https://www.techradar.com/news/chrome-is-making-it-easier-to-remember-passwords-and-sensitive-information` 
 
### What happens?

Because of the rule `@@||techradar.com$generichide` in the Fanboy's Enhanced Tracking list 
the rule `##.dfp-leaderboard-container` from EasyList is not applied, which results in a big white space above the article.

So or you remove the `@@||techradar.com$generichide` from Fanboy's Enhanced Tracking List  
 or you add `techradar.com##.dfp-leaderboard-container`

### List Subscriptions you're using:

- Fanboy's Enhanced Tracking
- EasyDutch
- EasyList
- EasyPrivacy
- uBlock filters
- uBlock unbreak

### Your settings

<!-- Just to ensure there is no issues or conflicts with other webbrowser extensions. 
     Disable Noscript, Ghostery, Disconnect, HTTPS Everywhere, Privacy Badger before reporting (and re-test with them disabled).
     Just ensure you're running just one Adblock extension only -->
| Question | Anwser | 
|  :--- | :---: |
| - OS/version: | Windows 10, 21H2 |
| - Browser/version: | MS Edge v98 |
| - Adblock Extension/version: | uBlock 1.41.2

### Other details:

none

</details>